### PR TITLE
Move stats to sessionStorage

### DIFF
--- a/static/bonuses.html
+++ b/static/bonuses.html
@@ -68,6 +68,7 @@
             <button class="big-button" id="start">Search for Questions and Start</button>
             <button class="big-button" id="reveal" onclick="reveal()">Reveal</button>
             <button class="big-button" id="next" onclick="readQuestion()">Next</button>
+            <button class="big-button" id="clear-stats" onclick="clearStats()">Clear stats</button>
         </div>
 
         <div class="options" id="options">

--- a/static/bonuses.js
+++ b/static/bonuses.js
@@ -13,8 +13,10 @@ var validCategories = [];
  * An array that represents
  * [# of 30's, # of 20's, # of 10's, # of 0's].
  */
-var stats = [0, 0, 0, 0];
+if (sessionStorage.getItem('stats')===null)
+    sessionStorage.setItem('stats',[0,0,0,0]);
 
+updateStatDisplay(); //update stats upon loading site
 
 /**
  * Called when the users wants to reveal the next bonus part.
@@ -40,23 +42,24 @@ var stats = [0, 0, 0, 0];
  * Calculates that points per bonus and updates the display.
  */
 function updateStatDisplay() {
-    let numBonuses = stats[0] + stats[1] + stats[2] + stats[3];
+    let statsArray = sessionStorage.stats.split(',');
+    let numBonuses = parseInt(statsArray[0]) + parseInt(statsArray[1]) + parseInt(statsArray[2]) + parseInt(statsArray[3]);
     let ppb = 0;
     let points = 0;
     if (numBonuses != 0) {
-        points = 30 * stats[0] + 20 * stats[1] + 10 * stats[2] + 0 * stats[3];
+        points = 30 * parseInt(statsArray[0]) + 20 * parseInt(statsArray[1]) + 10 * parseInt(statsArray[2]);
         ppb = Math.round(100 * points / numBonuses) / 100;
     }
     let includePlural = (numBonuses == 1) ? '' : 'es';
     document.getElementById('statline').innerHTML
-        = `${ppb} points per bonus with ${numBonuses} bonus${includePlural} seen (${stats[0]}/${stats[1]}/${stats[2]}/${stats[3]}, ${points} pts)`;
+        = `${ppb} points per bonus with ${numBonuses} bonus${includePlural} seen (${statsArray[0]}/${statsArray[1]}/${statsArray[2]}/${statsArray[3]}, ${points} pts)`;
 }
 
 /**
  * Clears user stats.
  */
 function clearStats() {
-    stats = [0, 0, 0, 0];
+    sessionStorage.setItem('stats', [0, 0, 0, 0]);
     updateStatDisplay();
 }
 
@@ -174,21 +177,29 @@ document.addEventListener('keyup', () => {
 });
 
 document.getElementById('30').addEventListener('click', () => {
-    stats[0]++;
+    let newStats = sessionStorage.stats.split(',');
+    newStats[0]=(parseInt(newStats[0])+1).toString();
+    sessionStorage.setItem('stats',newStats);
     updateStatDisplay();
 });
 
 document.getElementById('20').addEventListener('click', () => {
-    stats[1]++;
+    let newStats = sessionStorage.stats.split(',');
+    newStats[1]=(parseInt(newStats[1])+1).toString();
+    sessionStorage.setItem('stats',newStats);
     updateStatDisplay();
 });
 
 document.getElementById('10').addEventListener('click', () => {
-    stats[2]++;
+    let newStats = sessionStorage.stats.split(',');
+    newStats[2]=(parseInt(newStats[2])+1).toString();
+    sessionStorage.setItem('stats',newStats);
     updateStatDisplay();
 });
 
 document.getElementById('0').addEventListener('click', () => {
-    stats[3]++;
+    let newStats = sessionStorage.stats.split(',');
+    newStats[3]=(parseInt(newStats[3])+1).toString();
+    sessionStorage.setItem('stats',newStats);
     updateStatDisplay();
 });

--- a/static/bonuses.js
+++ b/static/bonuses.js
@@ -52,6 +52,13 @@ function updateStatDisplay() {
         = `${ppb} points per bonus with ${numBonuses} bonus${includePlural} seen (${stats[0]}/${stats[1]}/${stats[2]}/${stats[3]}, ${points} pts)`;
 }
 
+/**
+ * Clears user stats.
+ */
+function clearStats() {
+    stats = [0, 0, 0, 0];
+    updateStatDisplay();
+}
 
 /**
  * 
@@ -115,9 +122,6 @@ async function readQuestion() {
 
 
 document.getElementById('start').addEventListener('click', async () => {
-    stats = [0, 0, 0, 0];
-    updateStatDisplay();
-
     packetName = document.getElementById('name-select').value.trim();
     if (packetName.length == 0) {
         window.alert('Enter a packet name.');

--- a/static/tossups.html
+++ b/static/tossups.html
@@ -68,6 +68,7 @@
             <button class="big-button" id="start">Search for Questions and Start</button>
             <button class="big-button" id="buzz" onclick="buzz()">Buzz</button>
             <button class="big-button" id="next" onclick="readQuestion()">Next</button>
+            <button class="big-button" id="clear-stats" onclick="clearStats()">Clear stats</button>
         </div>
 
         <div class="options" id="options">

--- a/static/tossups.html
+++ b/static/tossups.html
@@ -191,8 +191,8 @@
             <p></p>
             <button id="category-select-button" onclick="document.getElementById('modal').style = ''">Adjust Categories</button>
             <p></p>
-            <div id="reading-speed-display">Reading speed [ms between words]: 220</div><br>
-            <input id="reading-speed" type="range" min="50" max="400" value="225">
+            <label for="reading-speed" id="reading-speed-display">Reading speed [ms between words]: 220</label><br>
+            <input id="reading-speed" type="range" min="50" max="400" step="10">
         </div>
 
         <div class="question-text" id="question-text">

--- a/static/tossups.js
+++ b/static/tossups.js
@@ -15,15 +15,32 @@ var shownAnswer = false;
 var validCategories = [];
 
 var inPower = false;
-var powers = 0;
-var tens = 0;
-var negs = 0;
-var dead = 0;
-var points = 0;
-var totalCelerity = 0;
+if (sessionStorage.getItem('powers')===null)
+    sessionStorage.setItem('powers',0);
+if (sessionStorage.getItem('tens')===null)
+    sessionStorage.setItem('tens',0);
+if (sessionStorage.getItem('negs')===null)
+    sessionStorage.setItem('negs',0);
+if (sessionStorage.getItem('dead')===null)
+    sessionStorage.setItem('dead',0);
+if (sessionStorage.getItem('points')===null)
+    sessionStorage.setItem('points',0);
+if (sessionStorage.getItem('totalCelerity')===null)
+    sessionStorage.setItem('totalCelerity',0);
 
 var toggleCorrectClicked = false;
 
+
+updateStatDisplay(); //update stats upon loading site
+
+/**
+ * Increases or decreases a session storage item by a certain amount.
+ * @param {String} item - The name of the sessionStorage item.
+ * @param {Number} x - The amount to increase/decrease the sessionStorage item.
+ */
+function shift(item, x) {
+    sessionStorage.setItem(item, parseFloat(sessionStorage.getItem(item))+x);
+}
 
 /**
  * Called when the users buzzes.
@@ -36,23 +53,23 @@ function buzz() {
         // Update scoring:
         inPower = !document.getElementById('question').innerHTML.includes('(*)') && questionText.includes('(*)');
         if (inPower) {
-            powers++;
+            shift('powers',1);
             if (packetName.includes('pace')) {
-                points += 20;
+                shift('points',20);
             }
             else {
-                points += 15;
+                shift('points',15);
             }
         }
         else {
-            tens++;
-            points += 10;
+            shift('tens',1);
+            shift('points',10);
         }
 
         // Update question text and show answer:
         let characterCount = document.getElementById('question').innerHTML.length;
         document.getElementById('question').innerHTML += questionTextSplit.join(' ');
-        totalCelerity += 1 - characterCount / document.getElementById('question').innerHTML.length;
+        shift('totalCelerity',1 - characterCount / document.getElementById('question').innerHTML.length);
         document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[currentQuestionNumber]['answer_sanitized'];
         document.getElementById('buzz').innerHTML = 'Buzz';
 
@@ -76,12 +93,12 @@ function buzz() {
  * Updates the displayed stat line.
  */
 function updateStatDisplay() {
-    let numTossups = powers + tens + negs + dead;
-    let celerity = numTossups != 0 ? totalCelerity / numTossups : 0;
+    let numTossups = parseInt(sessionStorage.powers) + parseInt(sessionStorage.tens) + parseInt(sessionStorage.negs) + parseInt(sessionStorage.dead);
+    let celerity = numTossups != 0 ? parseFloat(sessionStorage.totalCelerity) / numTossups : 0;
     celerity = Math.round(1000 * celerity) / 1000;
     let includePlural = (numTossups == 1) ? '' : 's';
     document.getElementById('statline').innerHTML
-        = `${powers}/${tens}/${negs} with ${numTossups} tossup${includePlural} seen (${points} pts, celerity: ${celerity})`;
+        = `${sessionStorage.powers}/${sessionStorage.tens}/${sessionStorage.negs} with ${numTossups} tossup${includePlural} seen (${sessionStorage.points} pts, celerity: ${celerity})`;
 }
 
 
@@ -89,7 +106,12 @@ function updateStatDisplay() {
  * Clears user stats.
  */
 function clearStats() {
-    powers=tens=negs=dead=points=totalCelerity=0;
+    sessionStorage.setItem('powers',0);
+    sessionStorage.setItem('tens',0);
+    sessionStorage.setItem('negs',0);
+    sessionStorage.setItem('dead',0);
+    sessionStorage.setItem('points',0);
+    sessionStorage.setItem('totalCelerity',0);
     updateStatDisplay();
 }
 
@@ -212,47 +234,47 @@ document.getElementById('start').addEventListener('click', async () => {
 document.getElementById('toggle-correct').addEventListener('click', () => {
     if (toggleCorrectClicked) {
         if (inPower) {
-            powers++;
+            shift('powers',1);
             if (packetName.includes('pace')) {
-                points += 20;
+                shift('points',20);
             }
             else {
-                points += 15;
+                shift('points',15);
             }
         }
         else {
-            tens++;
-            points += 10;
+            shift('tens',1);
+            shift('points',10);
         }
         if (questionTextSplit.length != 0) { // Check if there is more question to be read 
-            negs--;
-            points += 5;
+            shift('negs',-1);
+            shift('points',5);
         }
         else {
-            dead--;
+            shift('dead',-1);
         }
         document.getElementById('toggle-correct').innerHTML = 'I was wrong';
     }
     else {
         if (inPower) {
-            powers--;
+            shift('powers',-1);
             if (packetName.includes('pace')) {
-                points -= 20;
+                shift('points',-20);
             }
             else {
-                points -= 15;
+                shift('points',-15);
             }
         }
         else {
-            tens--;
-            points -= 10;
+            shift('tens',-1);
+            shift('points',-10);
         }
         if (questionTextSplit.length != 0) {
-            negs++;
-            points -= 5;
+            shift('negs',1);
+            shift('points',-5);
         }
         else {
-            dead++;
+            shift('dead',1);
         }
         document.getElementById('toggle-correct').innerHTML = 'I was right';
     }

--- a/static/tossups.js
+++ b/static/tossups.js
@@ -28,6 +28,12 @@ if (sessionStorage.getItem('points')===null)
 if (sessionStorage.getItem('totalCelerity')===null)
     sessionStorage.setItem('totalCelerity',0);
 
+if (localStorage.getItem('speed')===null)
+    localStorage.setItem('speed',220);
+
+document.getElementById('reading-speed-display').innerHTML = 'Reading speed [ms between words]: ' + localStorage.speed;
+document.getElementById('reading-speed').value = localStorage.speed;
+
 var toggleCorrectClicked = false;
 
 
@@ -296,5 +302,6 @@ document.addEventListener('keyup', () => {
 });
 
 document.getElementById('reading-speed').oninput = function () {
+    localStorage.setItem('speed',this.value);
     document.getElementById('reading-speed-display').innerHTML = 'Reading speed [ms between words]: ' + this.value;
 }


### PR DESCRIPTION
I've moved all stats into sessionStorage so the stats persist until the tab is closed or otherwise terminated. I've also added a clear stats button so stats can be cleared (before, refreshing was necessary). Additionally, I've made the number of points a separate sessionStorage item for tossups so the score doesn't change when the uses switches to/from a PACE packet.

I don't think moving the packet or question into sessionStorage is necessary, since it's pretty easy to get back to wherever you were after a refresh/restore.