### PR TITLE
Make reading speed more realistic

### DIFF
--- a/static/tossups.html
+++ b/static/tossups.html
@@ -191,8 +191,8 @@
             <p></p>
             <button id="category-select-button" onclick="document.getElementById('modal').style = ''">Adjust Categories</button>
             <p></p>
-            <label for="reading-speed" id="reading-speed-display">Reading speed [ms between words]: 220</label><br>
-            <input id="reading-speed" type="range" min="50" max="400" step="10">
+            <label for="reading-speed" id="reading-speed-display">Reading speed: 50</label><br>
+            <input id="reading-speed" type="range" min="0" max="100">
         </div>
 
         <div class="question-text" id="question-text">

--- a/static/tossups.js
+++ b/static/tossups.js
@@ -203,9 +203,9 @@ function printWord() {
         let time = Math.log(word.length)+1;
         if ((word.endsWith('.') && word.charCodeAt(word.length-2) > 96 && word.charCodeAt(word.length-2) < 123)
             || word.slice(-2) === '.\u201d' || word.slice(-2) === '!\u201d' || word.slice(-2) === '?\u201d')
-            time += 5;
+            time += 2;
         else if (word.endsWith(',') || word.slice(-2) === ',\u201d')
-            time += 2.5;
+            time += 0.75;
         else if (word === "(*)")
             time = 0;
         


### PR DESCRIPTION
Before, the reading speed for each word was constant, which is unrealistic; a person doesn't read "the" and "utilitarianism" at the same speed. Thus, I've made the reading speed vary word to word based on a couple of factors. The speed slider will now range from 0-100, with 0 being the slowest and 100 being the fastest.

Here's the new timing scheme:
- Powermark appears instantaneously.
- The time delay for each word is based on the natural logarithm of the word length with an upward shift of 1. I tried looking for research into any relationship between word length and reading time, but I didn't find anything. I also tried out basing the time off of an exponent, but I didn't like it as much. Feel free to modify if you find a function you like better.
- Words ending with periods receive extra delay if the second to last character is not uppercase. This makes it so things like E. coli aren't given this delay, but it does occasionally misfunction if the last word in the sentence is something like an uppercase physics symbol.
- Words ending with commas receive a smaller extra delay.
- Words ending with fancy quote (\u201d) will be checked to see if they have a comma or ending punctuation mark beforehand  in order to gain the respective extra delay.
- The reading time for each word will be scaled linearly based on the user-inputted reading speed.